### PR TITLE
fix: downgrade input-mask-ios for fixing ios builds

### DIFF
--- a/react-native-text-input-mask.podspec
+++ b/react-native-text-input-mask.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
     s.swift_version = "5.0"
     s.dependency 'React-Core'
     s.dependency 'React-RCTText'
-    s.dependency 'InputMask', '~> 6.1.0'
+    s.dependency 'InputMask', '~> 6.0.0'
   end


### PR DESCRIPTION
* Workaround for fixing ios build breaks #216 
* Found out you need to have xcode 12 (Which has the swift 5 compiler) to fix this without downgrading 