### PR TITLE
fix: Fix build on RN 0.65 and newer

### DIFF
--- a/react-native-text-input-mask.podspec
+++ b/react-native-text-input-mask.podspec
@@ -24,6 +24,5 @@ Pod::Spec.new do |s|
     s.requires_arc  = true
     s.swift_version = "5.0"
     s.dependency 'React-Core'
-    s.dependency 'React-RCTText'
     s.dependency 'InputMask', '~> 6.1.0'
   end


### PR DESCRIPTION
The RCTText dependency breaks Swift build.