### PR TITLE
support ios autocompleteOnFocus property

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -34,6 +34,7 @@ const TextInputMask = forwardRef<Handles, TextInputMaskProps>(({
     affinityCalculationStrategy,
     autocomplete= true,
     autoskip = true,
+    autocompleteOnFocus = true,
     rightToLeft,
     ...rest
 }, ref) => {
@@ -64,7 +65,7 @@ const TextInputMask = forwardRef<Handles, TextInputMaskProps>(({
   useEffect(() => {
     const nodeId = findNodeHandle(input.current)
     if (primaryFormat && nodeId) {
-      setMask(nodeId, primaryFormat, { affineFormats, affinityCalculationStrategy, customNotations, autocomplete, autoskip, rightToLeft })
+      setMask(nodeId, primaryFormat, { affineFormats, affinityCalculationStrategy, customNotations, autocomplete, autocompleteOnFocus, autoskip, rightToLeft })
     }
   }, [primaryFormat])
 
@@ -115,6 +116,7 @@ interface MaskOptions {
   affineFormats?: string[]
   customNotations?: Notation[]
   affinityCalculationStrategy?: AffinityCalculationStrategy
+  autocompleteOnFocus?: boolean
   /**
    * autocomplete pattern while editing text
    */

--- a/ios/TextInputMask.swift
+++ b/ios/TextInputMask.swift
@@ -39,13 +39,14 @@ class TextInputMask: NSObject, RCTBridgeModule, MaskedTextFieldDelegateListener 
                 guard let view = viewRegistry?[reactNode] as? RCTBaseTextInputView else { return }
                 let textView = view.backedTextInputView as! RCTUITextField
                 let autocomplete = options["autocomplete"] as? Bool ?? true
+                let autocompleteOnFocus = options["autocompleteOnFocus"] as? Bool ?? true
                 let autoskip = options["autoskip"] as? Bool ?? false
                 let affineFormats = options["affineFormats"] as? [String] ?? []
                 let customNotations = (options["customNotations"] as? [[String:Any]])?.map { $0.toNotation() } ?? []
                 let rightToLeft = options["rightToLeft"] as? Bool ?? false
                 var affinityCalculationStrategy = AffinityCalculationStrategy.forString(rawValue: options["affinityCalculationStrategy"] as? String)
                 
-                let maskedDelegate = MaskedTextFieldDelegate(primaryFormat: mask, autocomplete: autocomplete, autoskip: autoskip, affineFormats: affineFormats, customNotations: customNotations) { (_, value, complete) in
+                let maskedDelegate = MaskedTextFieldDelegate(primaryFormat: mask, autocomplete: autocomplete, autocompleteOnFocus: autocompleteOnFocus, autoskip: autoskip, affineFormats: affineFormats, customNotations: customNotations) { (_, value, complete) in
                     // trigger onChange directly to avoid trigger a second evaluation in native code (causes issue with some input masks like [00] {/} [00]
                     let textField = textView as! UITextField
                     view.onChange?([


### PR DESCRIPTION
Context:

on iOS, when user focuses empty input, cursor will placed before fixed part of the mask. For some masks it can be undesired: for example for '$[90].[99]' mask we would like to get cursor placed after "$" sign, and not before it.

iOS native library has [`autocompleteOnFocus` property](https://github.com/RedMadRobot/input-mask-ios/blob/master/Source/InputMask/InputMask/Classes/View/MaskedTextFieldDelegate.swift#L79), and setting it to "false" fixes the issue.

Solution:

Support `autocompleteOnFocus`  property on `TextInputMask` react and swift wrappers