### PR TITLE
Fix/readme-jest-mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,7 @@ import TextInputMask from 'react-native-text-input-mask';
 
 Make sure to [mock](https://jestjs.io/docs/en/manual-mocks#mocking-node-modules) the following to `jest.setup.js`:
 ```javascript
-jest.mock('react-native-text-input-mask', () => ({
-    default: jest.fn(),
-}))
+jest.mock('react-native-text-input-mask', () => 'TextInputMask');
 ```
 
 ## More info


### PR DESCRIPTION
I faced an error when i mocked with :

`jest.mock('react-native-text-input-mask', () => ({ default: jest.fn() }));`

so i switch to this:

`jest.mock('react-native-text-input-mask', () => 'TextInputMask');`

as I saw in this issue https://github.com/react-native-text-input-mask/react-native-text-input-mask/issues/234#issuecomment-1072625753